### PR TITLE
Add per-client Google Sheets output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ variables:
 - `BQ_DATASET` – dataset containing `FR_CUSTOMER` (default `raw_layer`)
 - `WRITE_TO_BQ` – set to `True` to upload the results to BigQuery
 - `CLIENT_IDS` – comma separated list of client IDs to filter on (optional)
+- `DRIVE_FOLDER_ID` – Google Drive folder to store per-client Sheets (optional)
 
 Run the tool:
 
@@ -30,6 +31,10 @@ Install dependencies using pip:
 ```bash
 pip install -r requirements.txt
 ```
+
+Google Sheets export requires additional credentials for ``gspread`` to
+authenticate. Ensure a service account JSON file is available and configured as
+described in the `gspread` documentation.
 
 ## Output
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,11 @@
 # master_audit_generator/main.py
 import os
 from utils import get_master_first_name, get_master_last_name
-from io_ops import read_customer_table, write_sheets
+from io_ops import (
+    read_customer_table,
+    write_sheets,
+    write_client_google_sheets,
+)
 from matching import generate_pairwise
 from aggregation import aggregate_groups
 
@@ -14,6 +18,7 @@ def generate_master_audit():
     clients = [c.strip() for c in clients_env.split(",") if c.strip()] if clients_env else None
 
     df = read_customer_table(project, dataset, clients)
+    folder_id = os.getenv("DRIVE_FOLDER_ID")
 
     # clean out Baton/dummy rows here (could be a utils function)
     # … you can factor that out too …
@@ -21,6 +26,7 @@ def generate_master_audit():
     pw_df = generate_pairwise(df)
     agg_df, client_df = aggregate_groups(pw_df, df, (get_master_first_name, get_master_last_name))
     write_sheets(pw_df, agg_df, client_df, to_bq, project)
+    write_client_google_sheets(pw_df, agg_df, client_df, folder_id)
 
 if __name__ == "__main__":
     generate_master_audit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ pandas
 pandas-gbq
 google-cloud-bigquery
 openpyxl
+gspread
+gspread_dataframe
+google-api-python-client


### PR DESCRIPTION
## Summary
- support writing individual Google Sheets per client
- expose `DRIVE_FOLDER_ID` env var and update README instructions
- require new dependencies for Google Sheets export

## Testing
- `pip install gspread gspread_dataframe google-api-python-client | tail -n 5`
- `python -m py_compile *.py && echo "py_compile success"`

------
https://chatgpt.com/codex/tasks/task_e_686459685f788324bc23acf97b950a73