### PR TITLE
Add DQLogger and instrument code with logging

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,26 @@
+import logging
+from typing import Any, Dict
+
+
+class DQLogger:
+    def __init__(self, name: str = __name__):
+        """A wrapper around Python logging with Cloud Logging defaults."""
+        root = logging.getLogger()
+        if not root.handlers:
+            logging.basicConfig(
+                level=logging.INFO,
+                format="%(asctime)s %(name)s [%(levelname)s] %(message)s",
+            )
+        self._std_logger = logging.getLogger(name)
+
+    def _format_message(self, message: str, extra: Dict[str, Any]) -> str:
+        return f"{message} {extra}" if extra else message
+
+    def info(self, message: str, **extra: Any) -> None:
+        self._std_logger.info(self._format_message(message, extra))
+
+    def warning(self, message: str, **extra: Any) -> None:
+        self._std_logger.warning(self._format_message(message, extra))
+
+    def error(self, message: str, **extra: Any) -> None:
+        self._std_logger.error(self._format_message(message, extra))

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 # master_audit_generator/main.py
 import os
+from logger import DQLogger
 from utils import get_master_first_name, get_master_last_name
 from io_ops import (
     read_customer_table,
@@ -9,7 +10,11 @@ from io_ops import (
 from matching import generate_pairwise
 from aggregation import aggregate_groups
 
+logger = DQLogger(__name__)
+
 def generate_master_audit():
+    logger.info("Starting master audit generation")
+
     project = os.getenv("BQ_PROJECT", "pco-qa")
     dataset = os.getenv("BQ_DATASET", "raw_layer")
     to_bq   = os.getenv("WRITE_TO_BQ", "False").lower() == "true"
@@ -17,16 +22,30 @@ def generate_master_audit():
     clients_env = os.getenv("CLIENT_IDS")
     clients = [c.strip() for c in clients_env.split(",") if c.strip()] if clients_env else None
 
+    logger.info(
+        "Reading customer table",
+        project=project,
+        dataset=dataset,
+        clients=clients,
+    )
     df = read_customer_table(project, dataset, clients)
     folder_id = os.getenv("DRIVE_FOLDER_ID")
 
     # clean out Baton/dummy rows here (could be a utils function)
     # … you can factor that out too …
 
+    logger.info("Generating pairwise matches")
     pw_df = generate_pairwise(df)
-    agg_df, client_df = aggregate_groups(pw_df, df, (get_master_first_name, get_master_last_name))
+    logger.info("Aggregating groups")
+    agg_df, client_df = aggregate_groups(
+        pw_df,
+        df,
+        (get_master_first_name, get_master_last_name),
+    )
+    logger.info("Writing sheets", to_bigquery=to_bq)
     write_sheets(pw_df, agg_df, client_df, to_bq, project)
     write_client_google_sheets(pw_df, agg_df, client_df, folder_id)
+    logger.info("Master audit generation complete")
 
 if __name__ == "__main__":
     generate_master_audit()

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,9 @@
 import pandas as pd
 import random
 from itertools import combinations
+from logger import DQLogger
+
+logger = DQLogger(__name__)
 
 BLANKS = {"", "nan", "none", "null", "n/a"}
 DUMMY_PHONES = {"0", "0000000000", "n/a", "none", "null", ""}
@@ -36,12 +39,16 @@ def sample_pairs(indices: list[int], sample_size: int) -> list[tuple[int,int]]:
     n = len(indices)
     total = n * (n - 1) // 2
     if total <= sample_size:
-        return list(combinations(indices, 2))
+        pairs = list(combinations(indices, 2))
+        logger.info("All pairs used", total=len(pairs))
+        return pairs
     pairs = set()
     while len(pairs) < sample_size:
         i, j = sorted(random.sample(indices, 2))
         pairs.add((i, j))
-    return list(pairs)
+    result = list(pairs)
+    logger.info("Sampled pairs", total=len(result))
+    return result
 
 def get_master_first_name(row: dict) -> str:
     keys = [


### PR DESCRIPTION
## Summary
- add a DQLogger utility for consistent logging
- log major steps and results in main flow
- add logging to IO operations and Google Sheets upload
- add logs for matching and aggregation steps
- log helper operations such as sampling pairs

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68645c1d86d0832499e7cede00d5673e