### PR TITLE
Handle missing CLIENT_IDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ variables:
 - `CLIENT_IDS` – comma separated list of client IDs to filter on (optional)
 - `DRIVE_FOLDER_ID` – Google Drive folder to store per-client Sheets (optional)
 
+When `CLIENT_IDS` is not provided, the tool retrieves all distinct clients from
+`FR_CUSTOMER` and processes them one by one.
+
 Run the tool:
 
 ```bash

--- a/io_ops.py
+++ b/io_ops.py
@@ -17,6 +17,19 @@ def remove_timezones(df: pd.DataFrame) -> pd.DataFrame:
         df[col] = df[col].dt.tz_localize(None)
     return df
 
+
+def list_clients(project: str, dataset: str) -> list[str]:
+    """Return all distinct client IDs from ``FR_CUSTOMER``."""
+    client = bigquery.Client(project=project)
+    query = (
+        f"SELECT DISTINCT CLIENT FROM `{project}.{dataset}.FR_CUSTOMER` "
+        "WHERE CLIENT IS NOT NULL ORDER BY CLIENT"
+    )
+    logger.info("Fetching list of clients", query=query)
+    df = client.query(query).to_dataframe()
+    col = "CLIENT" if "CLIENT" in df.columns else "Client"
+    return sorted(df[col].dropna().astype(str).tolist())
+
 def read_customer_table(
     project: str,
     dataset: str,

--- a/main.py
+++ b/main.py
@@ -1,11 +1,13 @@
 # master_audit_generator/main.py
 import os
+import pandas as pd
 from logger import DQLogger
 from utils import get_master_first_name, get_master_last_name
 from io_ops import (
     read_customer_table,
     write_sheets,
     write_client_google_sheets,
+    list_clients,
 )
 from matching import generate_pairwise
 from aggregation import aggregate_groups
@@ -19,32 +21,47 @@ def generate_master_audit():
     dataset = os.getenv("BQ_DATASET", "raw_layer")
     to_bq   = os.getenv("WRITE_TO_BQ", "False").lower() == "true"
 
-    clients_env = os.getenv("CLIENT_IDS")
-    clients = [c.strip() for c in clients_env.split(",") if c.strip()] if clients_env else None
-
-    logger.info(
-        "Reading customer table",
-        project=project,
-        dataset=dataset,
-        clients=clients,
-    )
-    df = read_customer_table(project, dataset, clients)
     folder_id = os.getenv("DRIVE_FOLDER_ID")
 
-    # clean out Baton/dummy rows here (could be a utils function)
-    # … you can factor that out too …
+    clients_env = os.getenv("CLIENT_IDS")
+    if clients_env:
+        batches = [[c.strip() for c in clients_env.split(",") if c.strip()]]
+    else:
+        all_clients = list_clients(project, dataset)
+        logger.info("No CLIENT_IDS provided; processing each client", count=len(all_clients))
+        batches = [[c] for c in all_clients]
 
-    logger.info("Generating pairwise matches")
-    pw_df = generate_pairwise(df)
-    logger.info("Aggregating groups")
-    agg_df, client_df = aggregate_groups(
-        pw_df,
-        df,
-        (get_master_first_name, get_master_last_name),
-    )
+    pw_frames = []
+    agg_frames = []
+    ci_frames = []
+
+    for batch in batches:
+        logger.info("Processing clients", clients=batch)
+        df = read_customer_table(project, dataset, batch)
+
+        logger.info("Generating pairwise matches")
+        pw_df = generate_pairwise(df)
+
+        logger.info("Aggregating groups")
+        agg_df, client_df = aggregate_groups(
+            pw_df,
+            df,
+            (get_master_first_name, get_master_last_name),
+        )
+
+        pw_frames.append(pw_df)
+        agg_frames.append(agg_df)
+        ci_frames.append(client_df)
+
+        write_client_google_sheets(pw_df, agg_df, client_df, folder_id)
+
+    pairwise = pd.concat(pw_frames, ignore_index=True) if len(pw_frames) > 1 else pw_frames[0]
+    aggregated = pd.concat(agg_frames, ignore_index=True) if len(agg_frames) > 1 else agg_frames[0]
+    client_df_final = pd.concat(ci_frames, ignore_index=True) if len(ci_frames) > 1 else ci_frames[0]
+
     logger.info("Writing sheets", to_bigquery=to_bq)
-    write_sheets(pw_df, agg_df, client_df, to_bq, project)
-    write_client_google_sheets(pw_df, agg_df, client_df, folder_id)
+    write_sheets(pairwise, aggregated, client_df_final, to_bq, project)
+
     logger.info("Master audit generation complete")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fetch distinct client ids from BigQuery with new `list_clients`
- run master audit for each client when `CLIENT_IDS` is not provided
- document default client processing behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68645f77f574832489ef92f5e5d0f8c0