### PR TITLE
Fix Google Sheets deletion

### DIFF
--- a/io_ops.py
+++ b/io_ops.py
@@ -138,8 +138,18 @@ def write_client_google_sheets(pairwise: pd.DataFrame,
         if files:
             file_id = files[0]["id"]
             ss = gc.open_by_key(file_id)
-            for ws in ss.worksheets():
-                ss.del_worksheet(ws)
+            worksheets = ss.worksheets()
+
+            # Google Sheets does not allow deleting the last remaining sheet in a
+            # spreadsheet.  We therefore keep one sheet until the new sheets are
+            # created and remove it afterwards.
+            temp_ws = None
+            if worksheets:
+                temp_ws = worksheets[0]
+                for ws in worksheets[1:]:
+                    ss.del_worksheet(ws)
+                temp_ws.clear()
+                temp_ws.update_title("temp")
         else:
             metadata = {
                 "name": file_name,
@@ -149,6 +159,7 @@ def write_client_google_sheets(pairwise: pd.DataFrame,
             created = drive.files().create(body=metadata, fields="id").execute()
             file_id = created["id"]
             ss = gc.open_by_key(file_id)
+            temp_ws = None
 
         for df, title in [
             (pw_df, "full masterAccount match"),
@@ -157,3 +168,6 @@ def write_client_google_sheets(pairwise: pd.DataFrame,
         ]:
             worksheet = ss.add_worksheet(title, rows=len(df) + 1, cols=len(df.columns) + 1)
             set_with_dataframe(worksheet, df, include_index=False)
+
+        if temp_ws is not None:
+            ss.del_worksheet(temp_ws)


### PR DESCRIPTION
## Summary
- ensure at least one sheet remains before deleting in client export

## Testing
- `python -m py_compile io_ops.py`
- `pip install -r requirements.txt`
- `python main.py` *(fails: Your default credentials were not found)*

------
https://chatgpt.com/codex/tasks/task_e_686465265e488324be376e19ce95ab19